### PR TITLE
ALF spec 1.1.0 update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 coverage
 node_modules
 !.env.example
+tester.js

--- a/README.md
+++ b/README.md
@@ -1,21 +1,23 @@
-# Mashape Analytics Node Agent
+# Galileo Node Agent
 
-> for more information on Mashape Analytics, please visit [apianalytics.com](https://www.apianalytics.com)
+Collect and send request records to Galileo for aggregation / logging
+
+> for more information on Galileo, please visit [getgalileo.io](https://getgalileo.io)
 
 ## Installation
 
 ``` sh
-npm install mashape-analytics --save
+npm install galileo-agent --save
 ```
 
 ## Usage
 
 ``` js
 var express = require('express')
-var analytics = require('mashape-analytics')
+var galileo = require('galileo-agent')
 
 var app = express()
-var agent = analytics('SERVICE_TOKEN')
+var agent = galileo('SERVICE_TOKEN')
 
 app.use(agent)
 
@@ -29,41 +31,53 @@ app.listen()
 ## API
 
 ```js
-var analytics = require('mashape-analytics')
+var galileo = require('galileo-agent')
 ```
 
-### analytics(serviceToken[, environment[, options]])
+### galileo(serviceToken[, environment[, options]])
 
-- **serviceToken**: `String` *(a Mashape Analytics Service Token)*
-- **environment**: `String` *(a Mashape Analytics Environment Slug)*
+- **serviceToken**: `String` *(a Galileo Service Token)*
+- **environment**: `String` *(a Galileo Environment Slug)*
 - **options**: `Object` *(Agent Configuration [Options](#options))*
 
 ```js
-analytics('SERVICE_TOKEN', 'PRODUCTION', {
+galileo('SERVICE_TOKEN', 'PRODUCTION', {
+  logBody: false,
   limits: {
     bodySize: 0
   },
   queue: {
     entries: 100
+  },
+  collector: {
+    host: 'collector.galileo.mashape.com',
+    port: 443,
+    path: '/1.1.0/single',
+    ssl: true
   }
 })
 ```
 
 ### Options
 
-| Name              | Description                                                                | Default |
-| ----------------- | -------------------------------------------------------------------------- | ------- |
-| `queue.entries`   | num of entries per [ALF](https://github.com/Mashape/api-log-format) object | `100`   |
-| `limits.bodysize` | limit captured *request & response* body size in bytes                     | `0`     |
+| Name                 | Description                                                                | Default |
+| -------------------- | -------------------------------------------------------------------------- | ------- |
+| `logBody`            | send body of request/response with ALF record                              | `false` |
+| `queue.entries`      | num of entries per [ALF](https://github.com/Mashape/api-log-format) object | `100`   |
+| `limits.bodysize`    | limit captured *request & response* body size in bytes                     | `1000`  |
+| `collector.host`     | specify the collector hostname to which you send your data                 | `'collector.galileo.mashape.com'`     |
+| `collector.port`     | specify the port of the collector server                                   | `443`     |
+| `collector.path`     | specify the versioning path of the collector server                        | `'/1.1.0/single'`     |
+| `collector.ssl`      | specify if the collector server has ssl enabled                            | `true`     |
 
 ## Examples
 
-- [HTTP](https://github.com/Mashape/analytics-agent-node/blob/master/examples/http.js)
-- [Express.js](https://github.com/Mashape/analytics-agent-node/blob/master/examples/express.js)
-- [Restify](https://github.com/Mashape/analytics-agent-node/blob/master/examples/restify.js)
+- [HTTP](https://github.com/Mashape/galileo-agent-node/blob/master/examples/http.js)
+- [Express.js](https://github.com/Mashape/galileo-agent-node/blob/master/examples/express.js)
+- [Restify](https://github.com/Mashape/galileo-agent-node/blob/master/examples/restify.js)
 
 ## Copyright and license
 
-Copyright Mashape Inc, 2015.
+Copyright Mashape Inc, 2016.
 
-Licensed under [the MIT License](https://github.com/Mashape/analytics-agent-node/blob/master/LICENSE)
+Licensed under [the MIT License](https://github.com/Mashape/galileo-agent-node/blob/master/LICENSE)

--- a/examples/express.js
+++ b/examples/express.js
@@ -1,11 +1,11 @@
 'use strict'
 
 var express = require('express')
-var analytics = require('mashape-analytics')
+var galileo = require('galileo-agent')
 
 var app = express()
 
-app.use(analytics('SERVICE_TOKEN'))
+app.use(galileo('SERVICE_TOKEN'))
 
 app.get('/api', function (req, res) {
   res.send('Hello World!')

--- a/examples/http.js
+++ b/examples/http.js
@@ -2,8 +2,8 @@
 
 var http = require('http')
 
-var analytics = require('mashape-analytics')
-var agent = analytics('SERVICE_TOKEN')
+var galileo = require('galileo-agent')
+var agent = galileo('SERVICE_TOKEN')
 
 var server = http.createServer(function (req, res) {
   agent(req, res)

--- a/examples/restify.js
+++ b/examples/restify.js
@@ -1,11 +1,11 @@
 'use strict'
 
 var restify = require('restify')
-var analytics = require('mashape-analytics')
+var galileo = require('galileo-agent')
 
 var server = restify.createServer()
 
-server.use(analytics('SERVICE_TOKEN'))
+server.use(galileo('SERVICE_TOKEN'))
 
 server.get('/api', function (req, res, next) {
   res.send('Hello World!')

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,7 +1,9 @@
 'use strict'
 
 var chalk = require('chalk')
-var debug = require('debug-log')('mashape-analytics')
+var debug = require('debug-log')('galileo')
+var fnDebug = require('debug-log')('function')
+var blockDebug = require('debug-log')('block')
 var extend = require('xtend')
 var helpers = require('./helpers')
 var Queue = require('./queue')
@@ -9,13 +11,17 @@ var url = require('url')
 var util = require('util')
 
 module.exports = function Agent (serviceToken, environment, options) {
+  fnDebug('Agent')
   // ensure agent key exists
   if (!serviceToken) {
-    throw new Error('a service token is required, visit: https://analytics.mashape.com/ to obtain one')
+    blockDebug('if !serviceToken', !serviceToken)
+    throw new Error('a service token is required, visit: https://galileo.mashape.com/ to obtain one')
   }
 
   // ensure instance type
   if (!(this instanceof Agent)) {
+    blockDebug('if !(this instanceof Agent)', !(this instanceof Agent))
+    fnDebug('not using "new" keyword. Reinstantiating.')
     return new Agent(serviceToken, environment, options)
   }
 
@@ -24,23 +30,31 @@ module.exports = function Agent (serviceToken, environment, options) {
 
   // no environment specified
   if (typeof environment === 'object') {
+    blockDebug("if typeof environment === 'object'", typeof environment === 'object')
     options = environment
     environment = null
   }
 
+  debug(options)
+
   // setup options with defaults
   self.opts = extend({
-    host: 'socket.analytics.mashape.com',
-    port: 443,
-    ssl: true,
+    logBody: false,
     limits: {
-      bodySize: 0
+      bodySize: 1000
     },
     queue: {
       batch: 1,
       entries: 100
+    },
+    collector: {
+      host: 'collector.galileo.mashape.com',
+      port: 443,
+      path: '/1.1.0/single',
+      ssl: true
     }
   }, options)
+  debug(options, self.opts)
 
   // setup request queue
   this.queue = new Queue(serviceToken, environment, self.opts)
@@ -49,6 +63,7 @@ module.exports = function Agent (serviceToken, environment, options) {
   // TODO use tamper or tamper-esque method to get raw body
   //      to determine raw content size to get infer compression size
   return function (req, res, next) {
+    fnDebug('middleware')
     var reqReceived = new Date()
 
     // assign clientIpAddress for each call
@@ -79,21 +94,25 @@ module.exports = function Agent (serviceToken, environment, options) {
     }
 
     // grab the request body
-    if (self.opts.limits.bodySize > 0) {
+    if (self.opts.logBody) {
+      blockDebug('if self.opts.logBody', self.opts.logBody)
       req.on('data', function (chunk) {
+        fnDebug("req.on('data'")
         bytes.req += chunk.length
 
         if (bytes.req <= self.opts.limits.bodySize) {
+          blockDebug('if bytes.req <= self.opts.limits.bodySize', bytes.req <= self.opts.limits.bodySize)
           chunked.req.push(chunk)
         }
       })
     }
 
     // construct the request body
-    if (self.opts.limits.bodySize > 0) {
+    if (self.opts.logBody) {
+      blockDebug('if self.opts.logBody', self.opts.logBody)
       req.on('end', function () {
+        fnDebug("req.on('end'", chunked.req)
         var body = Buffer.concat(chunked.req)
-
         bodies.req.size = body.length
         bodies.req.base64 = body.toString('utf8')
       })
@@ -107,28 +126,56 @@ module.exports = function Agent (serviceToken, environment, options) {
 
     // override node's http.ServerResponse.write method
     res.write = function (chunk, encoding) {
+      fnDebug('res.write')
       // call the original http.ServerResponse.write method
       func.write.call(res, chunk, encoding)
-
+      fnDebug('after firing original write')
       bytes.res += chunk.length
 
       if (bytes.res <= self.opts.limits.bodySize) {
+        blockDebug('if bytes.res <= self.opts.limits.bodySize', bytes.res <= self.opts.limits.bodySize)
         chunked.res.push(chunk)
       }
     }
 
     // override node's http.ServerResponse.end method
     res.end = function (data, encoding) {
+      fnDebug('res.end')
       // call the original http.ServerResponse.end method
       func.end.call(res, data, encoding)
+      fnDebug('after firing original end')
 
       if (chunked.res.length) {
+        blockDebug('if chunked.res.length', chunked.res.length)
+        chunked.res = chunked.res.map(function (chunk) {
+          if (chunk instanceof Buffer) {
+            return chunk
+          }
+          return new Buffer(chunk)
+        })
         data = Buffer.concat(chunked.res)
       }
 
       // construct body
       bodies.res.size = data ? data.length : 0
       bodies.res.base64 = data ? data.toString('utf8') : ''
+
+      if (self.opts.logBody) {
+        if (chunked.req.length) {
+          blockDebug('if chunked.req.length', chunked.req.length)
+          chunked.req = chunked.req.map(function (chunk) {
+            if (chunk instanceof Buffer) {
+              return chunk
+            }
+            return new Buffer(chunk)
+          })
+          data = Buffer.concat(chunked.req)
+        }
+
+        // construct body
+        bodies.req.size = data ? data.length : 0
+        bodies.req.base64 = data ? data.toString('utf8') : ''
+      }
 
       var agentResStartTime = new Date()
       var reqHeadersArr = helpers.objectToArray(req.headers)
@@ -147,10 +194,10 @@ module.exports = function Agent (serviceToken, environment, options) {
       var entry = {
         time: waitTime, // TODO
         serverIPAddress: helpers.getServerAddress(),
+        clientIPAddress: self.clientIPAddress,
         startedDateTime: agentResStartTime.toISOString(),
 
         request: {
-          cookies: [],
           method: req.method,
           url: util.format('%s://%s%s', protocol, req.headers.host, req.url),
           httpVersion: 'HTTP/' + req.httpVersion,
@@ -158,35 +205,32 @@ module.exports = function Agent (serviceToken, environment, options) {
           headers: reqHeadersArr,
           headersSize: helpers.getReqHeaderSize(req),
           bodySize: reqBodySize,
+          bodyCaptured: self.opts.logBody,
           postData: {
-            mimeType: helpers.getHeaderValue(reqHeadersArr, 'content-type', 'application/octet-stream'),
-            text: self.opts.limits.bodySize > 0 ? bodies.req.base64 : '' // TODO
+            text: self.opts.logBody ? bodies.req.base64 : '', // TODO
+            encoding: 'base64'
           }
         },
 
         response: {
-          cookies: [],
-          redirectURL: '',
           status: res.statusCode,
           statusText: resHeaders.statusText,
           httpVersion: resHeaders.version,
           headers: resHeaders.headersArr,
           headersSize: res._header ? new Buffer(res._header).length : 0,
           bodySize: resBodySize,
+          bodyCaptured: self.opts.logBody,
           content: {
             // TODO measure before compression, if any
-            size: resBodySize,
-            mimeType: helpers.getHeaderValue(resHeaders.headersArr, 'content-type', 'application/octet-stream'),
-            text: self.opts.limits.bodySize > 0 ? bodies.res.base64 : ''
+            text: self.opts.logBody ? bodies.res.base64 : '',
+            encoding: 'base64'
           }
         },
-
-        cache: {},
 
         timings: {
           send: 0, // TODO
           wait: waitTime,
-          receive: 0  // TODO
+          receive: 0 // TODO
         }
       }
 
@@ -197,6 +241,7 @@ module.exports = function Agent (serviceToken, environment, options) {
     }
 
     if (typeof next === 'function') {
+      blockDebug("if typeof next === 'function'", typeof next === 'function')
       next()
     }
   }

--- a/lib/index.js
+++ b/lib/index.js
@@ -2,8 +2,6 @@
 
 var chalk = require('chalk')
 var debug = require('debug-log')('galileo')
-var fnDebug = require('debug-log')('function')
-var blockDebug = require('debug-log')('block')
 var extend = require('xtend')
 var helpers = require('./helpers')
 var Queue = require('./queue')
@@ -11,17 +9,14 @@ var url = require('url')
 var util = require('util')
 
 module.exports = function Agent (serviceToken, environment, options) {
-  fnDebug('Agent')
   // ensure agent key exists
   if (!serviceToken) {
-    blockDebug('if !serviceToken', !serviceToken)
-    throw new Error('a service token is required, visit: https://galileo.mashape.com/ to obtain one')
+    throw new Error('a service token is required, visit: ' +
+      'https://galileo.mashape.com/ to obtain one')
   }
 
   // ensure instance type
   if (!(this instanceof Agent)) {
-    blockDebug('if !(this instanceof Agent)', !(this instanceof Agent))
-    fnDebug('not using "new" keyword. Reinstantiating.')
     return new Agent(serviceToken, environment, options)
   }
 
@@ -30,7 +25,7 @@ module.exports = function Agent (serviceToken, environment, options) {
 
   // no environment specified
   if (typeof environment === 'object') {
-    blockDebug("if typeof environment === 'object'", typeof environment === 'object')
+      typeof environment === 'object')
     options = environment
     environment = null
   }
@@ -39,20 +34,25 @@ module.exports = function Agent (serviceToken, environment, options) {
 
   // setup options with defaults
   self.opts = extend({
-    logBody: false,
+    logBody: false, // LOG_BODY agent spec
+    failLog: '/dev/null', // FAIL_LOG agent spec
     limits: {
-      bodySize: 1000
+      bodySize: 1000, // bytes
+      retry: 0, // R ETRY_COUNT agent spec
+      flush: 5, // seconds, FLUSH_TIMEOUT agent spec
+      connection: 30 // seconds, CONNECTION_TIMEOUT agent spec
     },
-    queue: {
-      batch: 1,
-      entries: 100
+    queue: { // QUEUE_SIZE agent spec
+      batch: 1, // number in a batch, if >1 switches path; `single` to `batch`
+      entries: 100 // number of entries per ALF record
     },
     collector: {
-      host: 'collector.galileo.mashape.com',
-      port: 443,
+      host: 'collector.galileo.mashape.com', // HOST agent spec
+      port: 443, // PORT agent spec
       path: '/1.1.0/single',
       ssl: true
     }
+
   }, options)
   debug(options, self.opts)
 
@@ -63,7 +63,6 @@ module.exports = function Agent (serviceToken, environment, options) {
   // TODO use tamper or tamper-esque method to get raw body
   //      to determine raw content size to get infer compression size
   return function (req, res, next) {
-    fnDebug('middleware')
     var reqReceived = new Date()
 
     // assign clientIpAddress for each call
@@ -95,13 +94,10 @@ module.exports = function Agent (serviceToken, environment, options) {
 
     // grab the request body
     if (self.opts.logBody) {
-      blockDebug('if self.opts.logBody', self.opts.logBody)
       req.on('data', function (chunk) {
-        fnDebug("req.on('data'")
         bytes.req += chunk.length
 
         if (bytes.req <= self.opts.limits.bodySize) {
-          blockDebug('if bytes.req <= self.opts.limits.bodySize', bytes.req <= self.opts.limits.bodySize)
           chunked.req.push(chunk)
         }
       })
@@ -109,9 +105,7 @@ module.exports = function Agent (serviceToken, environment, options) {
 
     // construct the request body
     if (self.opts.logBody) {
-      blockDebug('if self.opts.logBody', self.opts.logBody)
       req.on('end', function () {
-        fnDebug("req.on('end'", chunked.req)
         var body = Buffer.concat(chunked.req)
         bodies.req.size = body.length
         bodies.req.base64 = body.toString('utf8')
@@ -126,27 +120,21 @@ module.exports = function Agent (serviceToken, environment, options) {
 
     // override node's http.ServerResponse.write method
     res.write = function (chunk, encoding) {
-      fnDebug('res.write')
       // call the original http.ServerResponse.write method
       func.write.call(res, chunk, encoding)
-      fnDebug('after firing original write')
       bytes.res += chunk.length
 
       if (bytes.res <= self.opts.limits.bodySize) {
-        blockDebug('if bytes.res <= self.opts.limits.bodySize', bytes.res <= self.opts.limits.bodySize)
         chunked.res.push(chunk)
       }
     }
 
     // override node's http.ServerResponse.end method
     res.end = function (data, encoding) {
-      fnDebug('res.end')
       // call the original http.ServerResponse.end method
       func.end.call(res, data, encoding)
-      fnDebug('after firing original end')
 
       if (chunked.res.length) {
-        blockDebug('if chunked.res.length', chunked.res.length)
         chunked.res = chunked.res.map(function (chunk) {
           if (chunk instanceof Buffer) {
             return chunk
@@ -162,7 +150,6 @@ module.exports = function Agent (serviceToken, environment, options) {
 
       if (self.opts.logBody) {
         if (chunked.req.length) {
-          blockDebug('if chunked.req.length', chunked.req.length)
           chunked.req = chunked.req.map(function (chunk) {
             if (chunk instanceof Buffer) {
               return chunk
@@ -241,7 +228,6 @@ module.exports = function Agent (serviceToken, environment, options) {
     }
 
     if (typeof next === 'function') {
-      blockDebug("if typeof next === 'function'", typeof next === 'function')
       next()
     }
   }

--- a/lib/index.js
+++ b/lib/index.js
@@ -25,7 +25,6 @@ module.exports = function Agent (serviceToken, environment, options) {
 
   // no environment specified
   if (typeof environment === 'object') {
-      typeof environment === 'object')
     options = environment
     environment = null
   }

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -2,7 +2,10 @@
 
 var async = require('async')
 var chalk = require('chalk')
-var debug = require('debug-log')('mashape-analytics')
+var debug = require('debug-log')('galileo')
+var fnDebug = require('debug-log')('function')
+var dataDebug = require('debug-log')('data')
+fnDebug('')
 var http = require('http')
 var https = require('https')
 var pkg = require('../package.json')
@@ -12,15 +15,17 @@ var util = require('util')
  * ALF Queue
  */
 var Queue = module.exports = function (serviceToken, environment, options) {
+  fnDebug('Queue')
   var self = this
 
   this.opts = options
-  this.userAgent = util.format('%s/%s', 'mashape-analytics-agent-node', pkg.version)
+  this.userAgent = util.format('%s/%s', 'galileo-agent-node', pkg.version)
 
   // setup event queue
   // TODO specify worker pool
   // TODO use msgpack + gzip?
   this.queue = async.queue(function (entry, done) {
+    fnDebug('this.queue = async.queue')
     // append entry to log
     self.alf.har.log.entries.push(entry)
 
@@ -36,15 +41,14 @@ var Queue = module.exports = function (serviceToken, environment, options) {
 
   // init HAR object
   this.alf = {
-    version: '1.0.0',
+    version: '1.1.0',
     serviceToken: serviceToken,
     environment: environment || '',
 
     har: {
       log: {
-        version: '1.2',
         creator: {
-          name: 'mashape-analytics-agent-node',
+          name: 'galileo-agent-node',
           version: pkg.version
         },
 
@@ -58,13 +62,15 @@ var Queue = module.exports = function (serviceToken, environment, options) {
  * push entry to queue
  */
 Queue.prototype.push = function (entry) {
+  fnDebug('Queue.prototype.push')
   this.queue.push(entry)
 }
 
 /**
- * flush to socket server
+ * flush to collector server
  */
 Queue.prototype.flush = function () {
+  fnDebug('Queue.prototype.flush')
   debug('[%s] sending (%d)', chalk.yellow('agent'), this.alf.har.log.entries.length)
 
   // construct HTTP mesasge body
@@ -73,12 +79,12 @@ Queue.prototype.flush = function () {
   // immediatly reset entries object
   this.alf.har.log.entries = []
 
-  var client = this.opts.ssl ? https : http
+  var client = this.opts.collector.ssl ? https : http
 
   var request = client.request({
-    host: this.opts.host,
-    port: this.opts.port,
-    path: '/1.0.0/single',
+    host: this.opts.collector.host,
+    port: this.opts.collector.port,
+    path: this.opts.collector.path,
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
@@ -87,21 +93,26 @@ Queue.prototype.flush = function () {
   })
 
   request.on('response', function (res) {
+    fnDebug('request.on(\'response\'')
     var chunks = []
 
     res.on('data', function (chunk) {
+      fnDebug('res.on(\'data\'')
       chunks.push(chunk)
     })
 
     res.on('end', function () {
-      debug('[%s] %d %s: %s', chalk.magenta('socket'), res.statusCode, res.statusMessage, Buffer.concat(chunks))
+      fnDebug('res.on(\'end\'')
+      debug('[%s] %d %s: %s', chalk.magenta('collector'), res.statusCode, res.statusMessage, Buffer.concat(chunks))
     })
   })
 
   request.on('error', function (err) {
-    debug('[%s] problem with connection: %s', chalk.magenta('socket'), err.message)
+    fnDebug('request.on(\'error\'')
+    debug('[%s] problem with connection: %s', chalk.magenta('collector'), err.message)
   })
-
+  dataDebug(postData)
+  dataDebug(this.opts.collector.host, this.opts.collector.port, this.opts.collector.path)
   request.write(postData)
   request.end()
 }

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -3,9 +3,6 @@
 var async = require('async')
 var chalk = require('chalk')
 var debug = require('debug-log')('galileo')
-var fnDebug = require('debug-log')('function')
-var dataDebug = require('debug-log')('data')
-fnDebug('')
 var http = require('http')
 var https = require('https')
 var pkg = require('../package.json')
@@ -15,7 +12,6 @@ var util = require('util')
  * ALF Queue
  */
 var Queue = module.exports = function (serviceToken, environment, options) {
-  fnDebug('Queue')
   var self = this
 
   this.opts = options
@@ -25,7 +21,6 @@ var Queue = module.exports = function (serviceToken, environment, options) {
   // TODO specify worker pool
   // TODO use msgpack + gzip?
   this.queue = async.queue(function (entry, done) {
-    fnDebug('this.queue = async.queue')
     // append entry to log
     self.alf.har.log.entries.push(entry)
 
@@ -62,7 +57,6 @@ var Queue = module.exports = function (serviceToken, environment, options) {
  * push entry to queue
  */
 Queue.prototype.push = function (entry) {
-  fnDebug('Queue.prototype.push')
   this.queue.push(entry)
 }
 
@@ -70,7 +64,6 @@ Queue.prototype.push = function (entry) {
  * flush to collector server
  */
 Queue.prototype.flush = function () {
-  fnDebug('Queue.prototype.flush')
   debug('[%s] sending (%d)', chalk.yellow('agent'), this.alf.har.log.entries.length)
 
   // construct HTTP mesasge body
@@ -93,26 +86,20 @@ Queue.prototype.flush = function () {
   })
 
   request.on('response', function (res) {
-    fnDebug('request.on(\'response\'')
     var chunks = []
 
     res.on('data', function (chunk) {
-      fnDebug('res.on(\'data\'')
       chunks.push(chunk)
     })
 
     res.on('end', function () {
-      fnDebug('res.on(\'end\'')
       debug('[%s] %d %s: %s', chalk.magenta('collector'), res.statusCode, res.statusMessage, Buffer.concat(chunks))
     })
   })
 
   request.on('error', function (err) {
-    fnDebug('request.on(\'error\'')
     debug('[%s] problem with connection: %s', chalk.magenta('collector'), err.message)
   })
-  dataDebug(postData)
-  dataDebug(this.opts.collector.host, this.opts.collector.port, this.opts.collector.path)
   request.write(postData)
   request.end()
 }

--- a/package.json
+++ b/package.json
@@ -46,8 +46,6 @@
   },
   "devDependencies": {
     "alf-validator": "^3.1.1",
-    "async": "^1.5.2",
-    "body-parser": "^1.15.0",
     "codeclimate-test-reporter": "*",
     "echint": "^1.3.0",
     "express": "^4.13.4",
@@ -55,10 +53,7 @@
     "lodash": "^4.6.1",
     "mocha": "^2.2.5",
     "should": "^7.0.1",
-    "standard": "^4.3.1",
-    "supertest": "^1.2.0",
-    "tape": "^4.5.1",
-    "tape-catch": "^1.0.4"
+    "standard": "^4.3.1"
   },
   "dependencies": {
     "async": "^1.2.1",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.1.5",
+  "version": "2.0.0",
   "name": "galileo-agent",
   "description": "Node Agent for Galileo (https://getgalileo.io)",
   "author": "Mashape Inc. <opensource@mashape.com> (https://www.mashape.com/)",

--- a/package.json
+++ b/package.json
@@ -1,10 +1,19 @@
 {
   "version": "1.1.5",
-  "name": "mashape-analytics",
-  "description": "Node Agent for Mashape Analytics (https://analytics.mashape.com)",
+  "name": "galileo-agent",
+  "description": "Node Agent for Galileo (https://getgalileo.io)",
   "author": "Mashape Inc. <opensource@mashape.com> (https://www.mashape.com/)",
-  "homepage": "https://analytics.mashape.com",
-  "repository": "Mashape/analytics-agent-node",
+  "contributors": [
+    "Ahmad Nassri <ahmad@ahmadnassri.com> [@ahmadnassri] (https://www.ahmadnassri.com)",
+    "Kenneth Lee <kennethkl@gmail.com> [@kennethklee] (http://konquest.com)",
+    "Simon Grondin <github@simongrondin.name> [@SGrondin] (http://simongrondin.name)",
+    "Nijiko Yonskai <nijikokun@gmail.com> [@nijikokun] (http://nijikokun.com)",
+    "Thibault Charbonnier [@thibaultCha] (https://1991.io)",
+    "Montana Flynn <montana@montanaflynn.me> [@montanaflynn] (http://anonfunction.com)",
+    "Trent Oswald <trentoswald@therebelrobot.com> [@therebelrobot] (http://therebelrobot.com)"
+  ],
+  "homepage": "https://getgalileo.io",
+  "repository": "Mashape/galileo-agent-node",
   "license": "MIT",
   "main": "lib/index",
   "keywords": [
@@ -14,7 +23,8 @@
     "har",
     "http",
     "https",
-    "mashape"
+    "mashape",
+    "galileo"
   ],
   "engines": {
     "node": ">=0.10"
@@ -25,7 +35,7 @@
     "README.md"
   ],
   "bugs": {
-    "url": "https://github.com/Mashape/analytics-agent-node/issues"
+    "url": "https://github.com/Mashape/galileo-agent-node/issues"
   },
   "scripts": {
     "pretest": "standard && echint",
@@ -35,13 +45,20 @@
     "codeclimate": "codeclimate < coverage/lcov.info"
   },
   "devDependencies": {
+    "alf-validator": "^3.1.1",
+    "async": "^1.5.2",
+    "body-parser": "^1.15.0",
     "codeclimate-test-reporter": "*",
     "echint": "^1.3.0",
-    "express": "^4.13.0",
-    "istanbul": "^0.3.15",
+    "express": "^4.13.4",
+    "istanbul": "^0.3.22",
+    "lodash": "^4.6.1",
     "mocha": "^2.2.5",
     "should": "^7.0.1",
-    "standard": "^4.3.1"
+    "standard": "^4.3.1",
+    "supertest": "^1.2.0",
+    "tape": "^4.5.1",
+    "tape-catch": "^1.0.4"
   },
   "dependencies": {
     "async": "^1.2.1",


### PR DESCRIPTION
Updated service name ("Mashape Analytics" > "Galileo"), node module name, alf spec, added `logBody` like in Kong agent to settings to toggle body on/off, moved collector server info into a `collector` sub-object, added additional levels for debug each with greater fine-grained logs (`function`, `block`, `data`) and added contributors to package.json